### PR TITLE
chore: scikit-learn version fixes

### DIFF
--- a/EPL-Prediction-2018.ipynb
+++ b/EPL-Prediction-2018.ipynb
@@ -13,6 +13,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "!pip install scikit-learn==0.21.1\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "from matplotlib import pyplot as plt\n",

--- a/EPL-Prediction-2019.ipynb
+++ b/EPL-Prediction-2019.ipynb
@@ -13,6 +13,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "!pip install scikit-learn==0.21.1\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "from matplotlib import pyplot as plt\n",


### PR DESCRIPTION
- Fixes #1 it only predicts draw. 

downgraded python package `scikit-learn` to `0.21.1`